### PR TITLE
Queued Calls breaks with comma separated values.

### DIFF
--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -50,7 +50,7 @@ class Instrumental {
       if (data === 'ok\nok\n') {
         debug('Instrumental connected!');
         this.connected = true;
-        this.socket.write(this.queuedCalls.join());
+        this.socket.write(this.queuedCalls.join('\n'));
         this.queuedCalls = [];
       } else if (data === 'ok\nfail\n') {
         debug('Instrumental authentication failed!');


### PR DESCRIPTION
Replaces join(), with join('\n'), putting each metric on its own line which in testing resolves issue with all metrics past the first getting ignored.