### PR TITLE
Add notice functionality

### DIFF
--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -144,10 +144,10 @@ class Instrumental {
 
   notice(time, duration, description) {
     if (!time) {
-    time = Date.now();
+      time = Date.now();
     }
-     setImmediate(() => {
-    this.noticeApiCallInner('notice', time, duration, description);
+    setImmediate(() => {
+      this.noticeApiCallInner('notice', time, duration, description);
     });
   }
 

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -104,33 +104,33 @@ class Instrumental {
   }
 
   noticeApiCallInner(type, time, duration, desc) {
-  if(!this.enabled){ return; }
-  if (!time) {
-    time = Date.now();
-  }
-  time = Math.round(Number(time) / 1000);
-  if(duration === null || duration === undefined){ duration = 0; }
-  duration = Number(duration);
-  if(!isFinite(duration)){
-    debug('duration is invalid');
-    return;
-  }
-
-  var line = [type, time, duration, desc].join(' ') + '\n';
-  if (this.connected) {
-    this.socket.write(line);
-  }
-  else {
-    if (!this.socket) {
-      this.connect();
+    if(!this.enabled){ return; }
+    if (!time) {
+      time = Date.now();
     }
-    if (this.queuedCalls.length > 1000) {
-      debug('Queue too large - dropping notice event');
+    time = Math.round(Number(time) / 1000);
+    if(duration === null || duration === undefined){ duration = 0; }
+    duration = Number(duration);
+    if(!isFinite(duration)){
+      debug('duration is invalid');
       return;
     }
-    this.queuedCalls.push(line);
+
+    var line = [type, time, duration, desc].join(' ') + '\n';
+    if (this.connected) {
+      this.socket.write(line);
+    }
+    else {
+      if (!this.socket) {
+        this.connect();
+      }
+      if (this.queuedCalls.length > 1000) {
+        debug('Queue too large - dropping notice event');
+        return;
+      }
+      this.queuedCalls.push(line);
+    }
   }
-  };
 
   increment(metric, value, time, count){
     if(value === 0){ return; }

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -104,32 +104,32 @@ class Instrumental {
   }
 
   noticeApiCallInner(type, time, duration, desc) {
-	if(!this.enabled){ return; }
-	if (!time) {
-		time = Date.now();
-	}
-	time = Math.round(Number(time) / 1000);
-	if(duration === null || duration === undefined){ duration = 0; }
-	duration = Number(duration);
-	if(!isFinite(duration)){
-		debug('duration is invalid');
-		return;
-	}
+  if(!this.enabled){ return; }
+  if (!time) {
+    time = Date.now();
+  }
+  time = Math.round(Number(time) / 1000);
+  if(duration === null || duration === undefined){ duration = 0; }
+  duration = Number(duration);
+  if(!isFinite(duration)){
+    debug('duration is invalid');
+    return;
+  }
 
-	var line = [type, time, duration, desc].join(' ') + '\n';
-	if (this.connected) {
-		this.socket.write(line);
-	}
-	else {
-		if (!this.socket) {
-			this.connect();
-		}
-		if (this.queuedCalls.length > 1000) {
-			debug('Queue too large - dropping notice event');
-			return;
-		}
-		this.queuedCalls.push(line);
-	}
+  var line = [type, time, duration, desc].join(' ') + '\n';
+  if (this.connected) {
+    this.socket.write(line);
+  }
+  else {
+    if (!this.socket) {
+      this.connect();
+    }
+    if (this.queuedCalls.length > 1000) {
+      debug('Queue too large - dropping notice event');
+      return;
+    }
+    this.queuedCalls.push(line);
+  }
   };
 
   increment(metric, value, time, count){
@@ -144,10 +144,10 @@ class Instrumental {
 
   notice(time, duration, description) {
     if (!time) {
-		time = Date.now();
+    time = Date.now();
     }
-   	setImmediate(() => {
-		this.noticeApiCallInner('notice', time, duration, description);
+     setImmediate(() => {
+    this.noticeApiCallInner('notice', time, duration, description);
     });
   }
 

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -103,6 +103,35 @@ class Instrumental {
     }
   }
 
+  noticeApiCallInner(type, time, duration, desc) {
+	if(!this.enabled){ return; }
+	if (!time) {
+		time = Date.now();
+	}
+	time = Math.round(Number(time) / 1000);
+	if(duration === null || duration === undefined){ duration = 0; }
+	duration = Number(duration);
+	if(!isFinite(duration)){
+		debug('duration is invalid');
+		return;
+	}
+
+	var line = [type, time, duration, desc].join(' ') + '\n';
+	if (this.connected) {
+		this.socket.write(line);
+	}
+	else {
+		if (!this.socket) {
+			this.connect();
+		}
+		if (this.queuedCalls.length > 1000) {
+			debug('Queue too large - dropping notice event');
+			return;
+		}
+		this.queuedCalls.push(line);
+	}
+  };
+
   increment(metric, value, time, count){
     if(value === 0){ return; }
     if(value === null || value === undefined){ value = 1; }
@@ -111,6 +140,15 @@ class Instrumental {
 
   gauge(metric, value, time, count){
     this.apiCall('gauge', metric, value, time, count);
+  }
+
+  notice(time, duration, description) {
+    if (!time) {
+		time = Date.now();
+    }
+   	setImmediate(() => {
+		this.noticeApiCallInner('notice', time, duration, description);
+    });
   }
 
 }

--- a/test/intrumental-test.js
+++ b/test/intrumental-test.js
@@ -3,6 +3,7 @@
 var Instrumental = require('../lib/instrumental');
 var mitm = require('mitm');
 require('should');
+const VERSION = require('../package.json').version;
 
 describe('Instrumental', function() {
   beforeEach(function() { this.mitm = mitm(); });
@@ -10,7 +11,7 @@ describe('Instrumental', function() {
 
   it('should send gauge calls correctly', function(done) {
     var expectedData = [
-      ['hello version node/instrumental_agent/0.1.0\nauthenticate test\n', 'ok\nok\n'],
+      ['hello version node/instrumental_agent/'+VERSION+'\nauthenticate test\n', 'ok\nok\n'],
       ['gauge test.metric 5 1455477257 1\n']];
     var index = 0;
 
@@ -39,7 +40,7 @@ describe('Instrumental', function() {
 
   it('should send increment calls correctly', function(done) {
     var expectedData = [
-      ['hello version node/instrumental_agent/0.1.0\nauthenticate test\n', 'ok\nok\n'],
+      ['hello version node/instrumental_agent/'+VERSION+'\nauthenticate test\n', 'ok\nok\n'],
       ['increment test.metric 5 1455477257 1\n']];
     var index = 0;
 
@@ -57,14 +58,52 @@ describe('Instrumental', function() {
           expectedData.push(['increment test.metric2 1 ' +
             Math.round(Date.now()/1000) + ' 1\n']);
           I.increment('test.metric2');
-        } else if(index === 3) {
-          done();
+	  }
+	  else if(index === 3){
+		  expectedData.push(['increment test.metric3 1 ' +
+			Math.round(Date.now()/1000) + ' 1\n']);
+		  //this should trigger addition to the socket queue.
+		  I.increment('test.metric3');
+		  I.increment('test.metric4');
+
+	  }
+	  else if(index === 4) {
+		  expectedData.push(['increment test.metric4 1 ' +
+		  Math.round(Date.now()/1000) + ' 1\n']);
         }
+	  else if(index === 5){
+		  done();
+	  }
       });
     });
 
     I.increment('test.metric', 5, new Date(1455477257165));
     I.increment('discard.cause.zero', 0);
+  });
+
+  it('should send notice calls correctly', function(done) {
+    var expectedData = [
+      ['hello version node/instrumental_agent/'+VERSION+'\nauthenticate test\n', 'ok\nok\n'],
+      ['notice 1455477257 0 test is good\n']];
+    var index = 0;
+
+    var I = new Instrumental();
+    I.configure({apiKey: 'test', enabled: true});
+
+    this.mitm.on('connection', (socket) => {
+      socket.on('data', (data) => {
+        data.toString().should.equal(expectedData[index][0]);
+        if(expectedData[index][1])
+        { socket.write(expectedData[index][1]); }
+
+        index++;
+	        if(index === 2) {
+	          done();
+		  	}
+      });
+    });
+
+    I.notice(new Date(1455477257165),0,'test is good');
   });
 
 });

--- a/test/intrumental-test.js
+++ b/test/intrumental-test.js
@@ -58,22 +58,22 @@ describe('Instrumental', function() {
           expectedData.push(['increment test.metric2 1 ' +
             Math.round(Date.now()/1000) + ' 1\n']);
           I.increment('test.metric2');
-	  }
-	  else if(index === 3){
-		  expectedData.push(['increment test.metric3 1 ' +
-			Math.round(Date.now()/1000) + ' 1\n']);
-		  //this should trigger addition to the socket queue.
-		  I.increment('test.metric3');
-		  I.increment('test.metric4');
+    }
+    else if(index === 3){
+      expectedData.push(['increment test.metric3 1 ' +
+      Math.round(Date.now()/1000) + ' 1\n']);
+      //this should trigger addition to the socket queue.
+      I.increment('test.metric3');
+      I.increment('test.metric4');
 
-	  }
-	  else if(index === 4) {
-		  expectedData.push(['increment test.metric4 1 ' +
-		  Math.round(Date.now()/1000) + ' 1\n']);
+    }
+    else if(index === 4) {
+      expectedData.push(['increment test.metric4 1 ' +
+      Math.round(Date.now()/1000) + ' 1\n']);
         }
-	  else if(index === 5){
-		  done();
-	  }
+    else if(index === 5){
+      done();
+    }
       });
     });
 
@@ -97,9 +97,9 @@ describe('Instrumental', function() {
         { socket.write(expectedData[index][1]); }
 
         index++;
-	        if(index === 2) {
-	          done();
-		  	}
+          if(index === 2) {
+            done();
+        }
       });
     });
 


### PR DESCRIPTION
* Added `notice` method and `noticeInnerApiCall` to match pattern as currently developed and support Notice  events
* Modified previous change to queued metric joins to `join('')`, accounting for the fact each line has a newline already
* Updated Unit Tests to not have a fixed version number
* Added test for `notice`
* Added test of queued metrics

Fixes https://github.com/expectedbehavior/instrumental-node/issues/5